### PR TITLE
feat: 멤버 정보 저장 API 구현

### DIFF
--- a/src/main/java/com/unithon/aeio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/unithon/aeio/domain/member/controller/MemberController.java
@@ -1,0 +1,36 @@
+package com.unithon.aeio.domain.member.controller;
+
+import com.unithon.aeio.domain.member.dto.MemberRequest;
+import com.unithon.aeio.domain.member.dto.MemberResponse;
+import com.unithon.aeio.domain.member.entity.Member;
+import com.unithon.aeio.domain.member.service.MemberService;
+import com.unithon.aeio.global.result.ResultResponse;
+import com.unithon.aeio.global.result.code.MemberResultCode;
+import com.unithon.aeio.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@Tag(name = "01. 회원 API", description = "회원 도메인의 API입니다.")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    @Operation(summary = "회원정보 저장 API", description = "새로운 회원정보를 저장하는 API입니다.")
+    public ResultResponse<MemberResponse.MemberId> createMember(@RequestBody @Valid MemberRequest.MemberInfo request,
+                                                                @LoginMember Member member) {
+        return ResultResponse.of(MemberResultCode.CREATE_MEMBER,
+                memberService.createMember(request, member));
+    }
+
+
+}

--- a/src/main/java/com/unithon/aeio/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/unithon/aeio/domain/member/converter/MemberConverter.java
@@ -1,6 +1,7 @@
 package com.unithon.aeio.domain.member.converter;
 
 
+import com.unithon.aeio.domain.member.dto.MemberResponse;
 import com.unithon.aeio.domain.member.dto.OauthResponse;
 import com.unithon.aeio.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,14 @@ public class MemberConverter {
     // 회원가입 여부 체크
     public OauthResponse.CheckMemberRegistration toCheckMemberRegistration(boolean isRegistered) {
         return new OauthResponse.CheckMemberRegistration(isRegistered);
+    }
+
+    // member Id만 반환
+    public MemberResponse.MemberId toMemberId(Member member) {
+        return MemberResponse.MemberId
+                .builder()
+                .memberId(member.getId())
+                .build();
     }
 
 

--- a/src/main/java/com/unithon/aeio/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/MemberRequest.java
@@ -1,0 +1,37 @@
+package com.unithon.aeio.domain.member.dto;
+
+import com.unithon.aeio.domain.member.entity.Gender;
+import com.unithon.aeio.domain.member.entity.Worry;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public abstract class MemberRequest {
+
+    // 멤버 정보입력
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+
+        @NotBlank(message = "닉네임은 필수로 입력해야 합니다.")
+        @Size(max = 9, message = "닉네임은 최대 9자까지 설정할 수 있습니다.")
+        private String nickName;
+
+        @NotNull(message = "성별은 필수로 입력해야 합니다.")
+        private Gender gender;
+
+        @NotNull(message = "고민 부위는 최소 1개 이상이어야 합니다.")
+        @Size(max = 8, message = "고민 부위는 최대 8개까지 선택할 수 있습니다.")
+        private List<@NotBlank @Size(max = 10, message = "고민부위 이름은 최대 10자입니다.") String> worryList;
+    }
+
+}

--- a/src/main/java/com/unithon/aeio/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/MemberResponse.java
@@ -1,0 +1,18 @@
+package com.unithon.aeio.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class MemberResponse {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberId {
+        private Long memberId;
+    }
+
+}

--- a/src/main/java/com/unithon/aeio/domain/member/entity/Gender.java
+++ b/src/main/java/com/unithon/aeio/domain/member/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.unithon.aeio.domain.member.entity;
+
+public enum Gender {
+    FEMALE, MALE, NONE
+}

--- a/src/main/java/com/unithon/aeio/domain/member/entity/Member.java
+++ b/src/main/java/com/unithon/aeio/domain/member/entity/Member.java
@@ -1,12 +1,17 @@
 package com.unithon.aeio.domain.member.entity;
 
 import com.unithon.aeio.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +19,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -28,9 +36,9 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
-    @Column(nullable = false)
+    @Column
     private Long authId;
-    @Column(nullable = false)
+    @Column
     private String name;
     @Column
     private String email;      // Access Token
@@ -38,4 +46,17 @@ public class Member extends BaseTimeEntity {
     private String refreshToken;     // Refresh Token
     @Column
     private String accessToken;      // Access Token
+
+    @Column
+    @Size(max = 9)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private Gender gender;
+
+    @OneToMany(mappedBy = "member")
+    @Builder.Default
+    private List<Worry> worries = new ArrayList<>();
+
 }

--- a/src/main/java/com/unithon/aeio/domain/member/entity/Worry.java
+++ b/src/main/java/com/unithon/aeio/domain/member/entity/Worry.java
@@ -1,0 +1,42 @@
+package com.unithon.aeio.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "worry")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Worry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "worry_id")
+    private Long id;
+
+    @NotBlank
+    @Column(nullable = false)
+    @Size(max = 10)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/unithon/aeio/domain/member/repository/WorryRepository.java
+++ b/src/main/java/com/unithon/aeio/domain/member/repository/WorryRepository.java
@@ -1,0 +1,13 @@
+package com.unithon.aeio.domain.member.repository;
+
+import com.unithon.aeio.domain.member.entity.Worry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WorryRepository extends JpaRepository<Worry, Long> {
+    List<Worry> findAllByMemberId(Long memberId);
+}
+

--- a/src/main/java/com/unithon/aeio/domain/member/service/MemberService.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/MemberService.java
@@ -1,0 +1,9 @@
+package com.unithon.aeio.domain.member.service;
+
+import com.unithon.aeio.domain.member.dto.MemberRequest;
+import com.unithon.aeio.domain.member.dto.MemberResponse;
+import com.unithon.aeio.domain.member.entity.Member;
+
+public interface MemberService {
+    MemberResponse.MemberId createMember(MemberRequest.MemberInfo request, Member member);
+}

--- a/src/main/java/com/unithon/aeio/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,60 @@
+package com.unithon.aeio.domain.member.service;
+
+import com.unithon.aeio.domain.member.converter.MemberConverter;
+import com.unithon.aeio.domain.member.dto.MemberRequest;
+import com.unithon.aeio.domain.member.dto.MemberResponse;
+import com.unithon.aeio.domain.member.entity.Member;
+import com.unithon.aeio.domain.member.entity.Worry;
+import com.unithon.aeio.domain.member.repository.MemberRepository;
+import com.unithon.aeio.domain.member.repository.WorryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberConverter memberConverter;
+    private final WorryRepository worryRepository;
+
+    @Override
+    public MemberResponse.MemberId createMember(MemberRequest.MemberInfo request, Member loginMember) {
+        // 로그인 없을 때, 임시로 멤버 생성
+        Member member = getOrCreateMember(loginMember);
+        // 프로필 업데이트
+        member.setNickname(request.getNickName());
+        // 성별 업데이트
+        member.setGender(request.getGender());
+        // Member 저장
+        memberRepository.save(member);
+
+        // worryList 저장
+        List<Worry> worrieList = request.getWorryList()
+                .stream()
+                .map(name -> Worry
+                        .builder()
+                        .name(name)
+                        .member(member)      // FK 연관관계 세팅
+                        .build())
+                .toList();
+
+        worryRepository.saveAll(worrieList); // worryList 저장
+
+        return memberConverter.toMemberId(member);
+    }
+
+    // 멤버 찾고 없으면 저장하는 함수 (임시 로그인 패스 대용)
+    private Member getOrCreateMember(Member loginMember) {
+        if (loginMember != null && loginMember.getId() != null) {
+            return memberRepository.findById(loginMember.getId())
+                    .orElseGet(() -> memberRepository.save(Member.builder().build()));
+        }
+        // loginMember 자체가 null이거나 id가 없으면 바로 생성
+        return memberRepository.save(Member.builder().build());
+    }
+}

--- a/src/main/java/com/unithon/aeio/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/unithon/aeio/global/result/code/MemberResultCode.java
@@ -10,6 +10,7 @@ public enum MemberResultCode implements ResultCode {
     LOGIN(200, "SM000", "성공적으로 로그인하였습니다."),
     REFRESH_TOKEN(200, "SM001", "성공적으로 리프레쉬 토큰을 발급했습니다."),
     CHECK_MEMBER_REGISTRATION(200, "SM003", "해당 정보에 대응하는 회원의 가입 여부를 성공적으로 조회하였습니다."),
+    CREATE_MEMBER(200, "SM003", "성공적으로 멤버를 생성했습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/unithon/aeio/global/security/SecurityConfig.java
+++ b/src/main/java/com/unithon/aeio/global/security/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**",
                                 "/v3/api-docs/**").permitAll() // 스웨거 경로는 인증 없이 접근 가능
+                        .requestMatchers("/members/**").permitAll() //테스트 임시
+
                         .anyRequest().authenticated()) // 그 외 모든 요청은 인증이 필요
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션을 사용하지 않고, JWT로 인증을 관리
                 .formLogin(AbstractHttpConfigurer::disable) // 로그인 폼을 사용하지 않도록 설정
@@ -71,7 +73,9 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/v3/api-docs/**" // 스웨거 경로도 보안 필터에서 제외
+                                "/v3/api-docs/**", // 스웨거 경로도 보안 필터에서 제외
+
+                                "/members" //테스트 임시
                         );
     }
 }


### PR DESCRIPTION
닉네임: 최대9자
성별: FEMALE, MALE, NONE 중 하나로 입력
고민부위: 최소 1개, 최대 8개, 길이제한 10자로 입력

- 아직 클라이언트 측 로그인 기능이 완료되지 않아
테스트를 위해 securityConfig에서 보안경로 필터 제외하고,
memberId 없으면 새로 만드는 함수 구현해놓았습니다 (임시로)
(엔티티에서 nullable 필드 제외 포함)