### PR TITLE
[FEAT] presignedURL 발급 및 베이직 클래스 운동정보 저장 API

### DIFF
--- a/src/main/java/com/unithon/aeio/domain/practice/controller/PracticeLogController.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/controller/PracticeLogController.java
@@ -1,0 +1,41 @@
+package com.unithon.aeio.domain.practice.controller;
+
+import com.unithon.aeio.domain.practice.converter.PracticeLogConverter;
+import com.unithon.aeio.domain.practice.dto.PracticeLogRequest;
+import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
+import com.unithon.aeio.domain.practice.service.PracticeLogService;
+import com.unithon.aeio.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.unithon.aeio.global.result.code.ClassResultCode.CREATE_PRESIGNED_URL;
+
+@RestController
+@Slf4j
+@RequestMapping("/practiceLog")
+@Tag(name = "03. 일별 운동정보 API", description = "일별 운동정보를 CRUD하는 API입니다.")
+@RequiredArgsConstructor
+public class PracticeLogController {
+
+    private final PracticeLogService practiceLogService;
+    private final PracticeLogConverter practiceLogConverter;
+
+    @PostMapping("/preSignedUrl")
+    @Operation(summary = "Presigned URL 요청 API", description = "Presigned URL을 요청하는 API입니다.")
+    public ResultResponse<PracticeLogResponse.PreSignedUrlList> getPreSignedUrlList(@Valid @RequestBody PracticeLogRequest.PreSignedUrlRequest request) {
+        long startTime = System.currentTimeMillis();
+        List<PracticeLogResponse.PreSignedUrl> preSignedUrlList = practiceLogService.getPreSignedUrlList(request);
+        long finishTime = System.currentTimeMillis();
+        log.info("PhotoServiceImpl.getPreSignedUrlList() 수행 시간: {} ms", finishTime - startTime);
+        return ResultResponse.of(CREATE_PRESIGNED_URL, practiceLogConverter.toPreSignedUrlList(preSignedUrlList));
+    }
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/controller/PracticeLogController.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/controller/PracticeLogController.java
@@ -1,10 +1,12 @@
 package com.unithon.aeio.domain.practice.controller;
 
+import com.unithon.aeio.domain.member.entity.Member;
 import com.unithon.aeio.domain.practice.converter.PracticeLogConverter;
 import com.unithon.aeio.domain.practice.dto.PracticeLogRequest;
 import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
 import com.unithon.aeio.domain.practice.service.PracticeLogService;
 import com.unithon.aeio.global.result.ResultResponse;
+import com.unithon.aeio.global.security.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -13,15 +15,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static com.unithon.aeio.global.result.code.ClassResultCode.CREATE_BASIC_LOG;
 import static com.unithon.aeio.global.result.code.ClassResultCode.CREATE_PRESIGNED_URL;
 
 @RestController
 @Slf4j
-@RequestMapping("/practiceLog")
+@RequestMapping("/practice")
 @Tag(name = "03. 일별 운동정보 API", description = "일별 운동정보를 CRUD하는 API입니다.")
 @RequiredArgsConstructor
 public class PracticeLogController {
@@ -37,5 +41,14 @@ public class PracticeLogController {
         long finishTime = System.currentTimeMillis();
         log.info("PhotoServiceImpl.getPreSignedUrlList() 수행 시간: {} ms", finishTime - startTime);
         return ResultResponse.of(CREATE_PRESIGNED_URL, practiceLogConverter.toPreSignedUrlList(preSignedUrlList));
+    }
+
+    @PostMapping("/basic")
+    @Operation(summary = "베이직 클래스 - 일별 운동정보 저장 API", description = "베이직 클래스를 수행했을 때 일별 운동정보를 저장하는 API 입니다.")
+    public ResultResponse<PracticeLogResponse.PracticeLogId> uploadPhotos(@RequestParam("classId") Long classId,
+                                                                          @LoginMember Member member,
+                                                                          @RequestBody @Valid PracticeLogRequest.BasicLog request) {
+        return ResultResponse.of(CREATE_BASIC_LOG,
+                practiceLogService.createBasicLog(classId, member, request));
     }
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/converter/PracticeLogConverter.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/converter/PracticeLogConverter.java
@@ -1,0 +1,40 @@
+package com.unithon.aeio.domain.practice.converter;
+
+import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class PracticeLogConverter {
+
+    //presigned url 리스트
+    public PracticeLogResponse.PreSignedUrlList toPreSignedUrlList(List<PracticeLogResponse.PreSignedUrl> preSignedUrlList) {
+        List<PracticeLogResponse.PreSignedUrl> preSignedUrlInfoList = preSignedUrlList
+                .stream()
+                .map(preSignedUrlInfo -> toPreSignedUrl(
+                        preSignedUrlInfo.getPreSignedUrl(),
+                        preSignedUrlInfo.getPhotoUrl(),
+                        preSignedUrlInfo.getPhotoName()
+                ))
+                .collect(Collectors.toList());
+
+        return PracticeLogResponse.PreSignedUrlList
+                .builder()
+                .preSignedUrlInfoList(preSignedUrlInfoList)
+                .build();
+    }
+
+    public PracticeLogResponse.PreSignedUrl toPreSignedUrl(String preSignedUrl, String photoUrl, String photoName) {
+        return PracticeLogResponse.PreSignedUrl
+                .builder()
+                .preSignedUrl(preSignedUrl)
+                .photoUrl(photoUrl)
+                .photoName(photoName)
+                .build();
+    }
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/converter/PracticeLogConverter.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/converter/PracticeLogConverter.java
@@ -1,6 +1,9 @@
 package com.unithon.aeio.domain.practice.converter;
 
+import com.unithon.aeio.domain.member.dto.MemberResponse;
+import com.unithon.aeio.domain.member.entity.Member;
 import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
+import com.unithon.aeio.domain.practice.entity.PracticeLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -35,6 +38,14 @@ public class PracticeLogConverter {
                 .preSignedUrl(preSignedUrl)
                 .photoUrl(photoUrl)
                 .photoName(photoName)
+                .build();
+    }
+
+    // id만 반환
+    public PracticeLogResponse.PracticeLogId toPracticeLogId(PracticeLog practiceLog) {
+        return PracticeLogResponse.PracticeLogId
+                .builder()
+                .practiceLogId(practiceLog.getId())
                 .build();
     }
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogRequest.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogRequest.java
@@ -1,6 +1,7 @@
 package com.unithon.aeio.domain.practice.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,4 +20,19 @@ public abstract class PracticeLogRequest {
         @NotEmpty(message = "사진의 이름은 하나 이상이어야 합니다.")
         private List<String> photoNameList;
     }
+
+    // 베이직 클래스 운동기록 생성
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BasicLog {
+        @NotEmpty(message = "무표정 사진url은 필수로 입력해야 합니다.")
+        private String expressionlessPhoto;
+        @Size(max=100, message = "최대 100자까지 입력할 수 있습니다.")
+        private String feedBack;
+        private Integer count;
+    }
+
+
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogRequest.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogRequest.java
@@ -1,0 +1,22 @@
+package com.unithon.aeio.domain.practice.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public abstract class PracticeLogRequest {
+
+    // presigned url 요청
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PreSignedUrlRequest {
+        @NotEmpty(message = "사진의 이름은 하나 이상이어야 합니다.")
+        private List<String> photoNameList;
+    }
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogResponse.java
@@ -1,0 +1,28 @@
+package com.unithon.aeio.domain.practice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public abstract class PracticeLogResponse {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PreSignedUrlList {
+        private List<PreSignedUrl> preSignedUrlInfoList;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PreSignedUrl {
+        private String preSignedUrl;
+        private String photoUrl;
+        private String photoName;
+    }
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/dto/PracticeLogResponse.java
@@ -25,4 +25,12 @@ public abstract class PracticeLogResponse {
         private String photoUrl;
         private String photoName;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PracticeLogId {
+        private Long practiceLogId;
+    }
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/entity/PracticeLog.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/entity/PracticeLog.java
@@ -1,4 +1,55 @@
 package com.unithon.aeio.domain.practice.entity;
 
-public class PracticeLog {
+import com.unithon.aeio.domain.classes.entity.Classes;
+import com.unithon.aeio.domain.member.entity.Member;
+import com.unithon.aeio.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "practice_log")
+@SQLRestriction("deleted_at is NULL")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PracticeLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "practice_log_id")
+    private Long id;
+
+    @Column
+    private String expressionlessPhoto; //무표정 사진 URL
+    @Column
+    private String smilePhoto; //웃는 사진 URL
+    @Column
+    private String feedBack;
+    @Column
+    private Integer count; //몇번 했는지
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id")
+    private Classes classes;
+
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/entity/PracticeLog.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/entity/PracticeLog.java
@@ -1,0 +1,4 @@
+package com.unithon.aeio.domain.practice.entity;
+
+public class PracticeLog {
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/repository/PracticeLogRepository.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/repository/PracticeLogRepository.java
@@ -1,0 +1,9 @@
+package com.unithon.aeio.domain.practice.repository;
+
+import com.unithon.aeio.domain.practice.entity.PracticeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PracticeLogRepository extends JpaRepository<PracticeLog, Long> {
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogService.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogService.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface PracticeLogService {
     List<PracticeLogResponse.PreSignedUrl> getPreSignedUrlList(PracticeLogRequest.PreSignedUrlRequest request);
+    PracticeLogResponse.PracticeLogId createBasicLog(Long classId, Member member, PracticeLogRequest.BasicLog request);
 }

--- a/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogService.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogService.java
@@ -1,0 +1,11 @@
+package com.unithon.aeio.domain.practice.service;
+
+import com.unithon.aeio.domain.member.entity.Member;
+import com.unithon.aeio.domain.practice.dto.PracticeLogRequest;
+import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
+
+import java.util.List;
+
+public interface PracticeLogService {
+    List<PracticeLogResponse.PreSignedUrl> getPreSignedUrlList(PracticeLogRequest.PreSignedUrlRequest request);
+}

--- a/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogServiceImpl.java
+++ b/src/main/java/com/unithon/aeio/domain/practice/service/PracticeLogServiceImpl.java
@@ -1,0 +1,94 @@
+package com.unithon.aeio.domain.practice.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.unithon.aeio.domain.practice.converter.PracticeLogConverter;
+import com.unithon.aeio.domain.practice.dto.PracticeLogRequest;
+import com.unithon.aeio.domain.practice.dto.PracticeLogResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@Slf4j
+@RequiredArgsConstructor
+public class PracticeLogServiceImpl implements PracticeLogService {
+
+    private final AmazonS3 amazonS3;
+    private final PracticeLogConverter practiceLogConverter;
+
+    @Value("${spring.cloud.aws.s3.photo-bucket}")
+    private String BUCKET_NAME;
+    @Value("${spring.cloud.aws.region.static}")
+    private String REGION;
+
+    public static final String RAW_PATH_PREFIX = "photo";
+
+    // presigned url 리스트
+    @Override
+    public List<PracticeLogResponse.PreSignedUrl> getPreSignedUrlList(PracticeLogRequest.PreSignedUrlRequest request) {
+        return request.getPhotoNameList()
+                .stream()
+                .map(this::getPreSignedUrl)
+                .collect(Collectors.toList());
+    }
+
+    // presigned url
+    private PracticeLogResponse.PreSignedUrl getPreSignedUrl(String originalFilename) {
+        String fileName = createPath(originalFilename);
+        String photoName = fileName.split("/")[1];
+        String photoUrl = generateFileAccessUrl(fileName);
+
+        URL preSignedUrl = amazonS3.generatePresignedUrl(getGeneratePreSignedUrlRequest(BUCKET_NAME, fileName));
+        return practiceLogConverter.toPreSignedUrl(preSignedUrl.toString(), photoUrl, photoName);
+    }
+
+    // 원본 사진 전체 경로 생성
+    private String createPath(String fileName) {
+        String fileId = createFileId();
+        return String.format("%s/%s", RAW_PATH_PREFIX, fileId + fileName);
+    }
+
+    // 사진 고유 ID 생성
+    private String createFileId() {
+        return UUID.randomUUID().toString();
+    }
+
+    // 원본 사진의 접근 URL 생성
+    private String generateFileAccessUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", BUCKET_NAME, REGION, fileName);
+    }
+
+    // 사진 업로드용(PUT) PreSigned URL 생성
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(getPreSignedUrlExpiration());
+        generatePresignedUrlRequest.addRequestParameter(Headers.S3_CANNED_ACL, CannedAccessControlList.PublicRead.toString());
+
+        return generatePresignedUrlRequest;
+    }
+
+    // PreSigned URL 유효 기간 설정
+    private Date getPreSignedUrlExpiration() {
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60 * 3;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    // ---------- 여기까지 presigned
+}

--- a/src/main/java/com/unithon/aeio/global/error/code/JwtErrorCode.java
+++ b/src/main/java/com/unithon/aeio/global/error/code/JwtErrorCode.java
@@ -13,6 +13,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(403, "EJ004", "유효하지않은 리프레시 토큰입니다."),
     MEMBER_NOT_FOUND(404, "EJ005", "해당 회원이 존재하지 않습니다. 탈퇴한 회원인지 확인해 주세요."),
     MEMBER_NOT_FOUND_BY_AUTH_ID(405, "EG006", "authId로 멤버를 찾을 수 없습니다."),
+    CLASS_NOT_FOUND(405, "EG007", "클래스를 찾을 수 없습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/unithon/aeio/global/result/code/ClassResultCode.java
+++ b/src/main/java/com/unithon/aeio/global/result/code/ClassResultCode.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ClassResultCode implements ResultCode {
     CREATE_CLASS(200, "SC000", "성공적으로 클래스를 생성했습니다."),
+    CREATE_PRESIGNED_URL(200, "SC001", "성공적으로 presigned url을 생성했습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/unithon/aeio/global/result/code/ClassResultCode.java
+++ b/src/main/java/com/unithon/aeio/global/result/code/ClassResultCode.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ClassResultCode implements ResultCode {
     CREATE_CLASS(200, "SC000", "성공적으로 클래스를 생성했습니다."),
     CREATE_PRESIGNED_URL(200, "SC001", "성공적으로 presigned url을 생성했습니다."),
+    CREATE_BASIC_LOG(200, "SC002", "기본 클래스의 운동 기록을 성공적으로 생성했습니다."),
     ;
     private final int status;
     private final String code;


### PR DESCRIPTION
사진을 업로드할 PresignedUrl을 AWS에게 요청하는 API입니다.
클라이언트는 업로드할 이미지의 정보를 포함한 POST 요청을 서버에 보냅니다.
서버는 요청받은 정보를 바탕으로 AWS S3와 같은 스토리지 서비스에 업로드할 수 있는 presigned URL을 생성합니다.
서버는 생성된 프리사인드 URL을 클라이언트에게 응답으로 보냅니다. 이 URL은 제한된 시간 동안 유효하며, 해당 시간 내에만 업로드가 가능합니다.
클라이언트는 응답받은 presigned URL을 사용하여 이미지 파일을 직접 스토리지 서비스(S3 등)에 업로드합니다.

'일별 운동 정보'에 사진을 업로드하는 API 입니다
해당 API는 presigned url 요청과 응답, S3 업로드 처리를 완료했다는 것을 가정하고 호출됩니다.
이때 class id와 member id를 조합해 '누가 어떤 운동을 했는지' 정보 또한 함께 저장합니다.
입력한 클래스 id가 유효하지 않으면 에러를 뱉어냅니다.