### PR TITLE
[FEAT] 애플 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// security
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly	'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/unithon/aeio/domain/member/controller/MemberController.java
+++ b/src/main/java/com/unithon/aeio/domain/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.unithon.aeio.domain.member.controller;
 
-import com.unithon.aeio.domain.classes.dto.ClassResponse;
 import com.unithon.aeio.domain.member.dto.MemberRequest;
 import com.unithon.aeio.domain.member.dto.MemberResponse;
 import com.unithon.aeio.domain.member.entity.Member;

--- a/src/main/java/com/unithon/aeio/domain/member/controller/OauthController.java
+++ b/src/main/java/com/unithon/aeio/domain/member/controller/OauthController.java
@@ -3,6 +3,7 @@ package com.unithon.aeio.domain.member.controller;
 import com.unithon.aeio.domain.member.converter.MemberConverter;
 import com.unithon.aeio.domain.member.dto.OauthRequest;
 import com.unithon.aeio.domain.member.dto.OauthResponse;
+import com.unithon.aeio.domain.member.service.AppleOauthService;
 import com.unithon.aeio.domain.member.service.OauthService;
 import com.unithon.aeio.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.unithon.aeio.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
@@ -21,14 +23,15 @@ import static com.unithon.aeio.global.result.code.MemberResultCode.LOGIN;
 import static com.unithon.aeio.global.result.code.MemberResultCode.REFRESH_TOKEN;
 
 @RestController
-@RequestMapping
+@RequestMapping("/login")
 @Tag(name = "00. 인증,인가 관련 API", description = "회원의 회원가입 및 로그인 등을 처리하는 API입니다.")
 @RequiredArgsConstructor
 public class OauthController {
 
     private final OauthService oauthService;
+    private final AppleOauthService appleOauthService;
 
-    @PostMapping("/login/oauth")
+    @PostMapping("/oauth")
     @Operation(summary = "로그인 API", description = "카카오톡을 통해 서비스에 로그인하는 API입니다.")
     public ResultResponse<OauthResponse.ServerAccessTokenInfo> login(@RequestBody OauthRequest.FrontAccessTokenInfo oauthRequest,
                                                                      HttpServletResponse response) { //HTTP 응답 조작: Refresh Token을 클라이언트의 브라우저 쿠키에 저장할 때 사용
@@ -36,17 +39,24 @@ public class OauthController {
     }
 
     // 리프레시 토큰으로 액세스토큰 재발급 받는 로직
-    @PostMapping("/login/token/refresh")
+    @PostMapping("/token/refresh")
     @Operation(summary = "액세스토큰 재발급 API", description = "리프레시 토큰으로 액세스토큰을 재발급 받는 API입니다.")
     public ResultResponse<OauthResponse.RefreshTokenResponse> tokenRefresh(HttpServletRequest request) { //request: 클라이언트가 서버에 보낸 HTTP 요청에 포함된 쿠키를 가져오기 위함
         return ResultResponse.of(REFRESH_TOKEN, oauthService.tokenRefresh(request));
     }
 
     // 특정 authId를 가진 회원의 회원가입 여부 조회
-    @PostMapping("/login/check-registration")
+    @PostMapping("/check-registration")
     @Operation(summary = "회원가입 여부 조회 API", description = "authId를 통해, 해당 정보와 일치하는 회원의 가입 여부를 조회하는 API입니다.")
     public ResultResponse<OauthResponse.CheckMemberRegistration> checkSignup(@Valid @RequestBody OauthRequest.LoginRequest request) {
         return ResultResponse.of(CHECK_MEMBER_REGISTRATION, oauthService.checkRegistration(request));
+    }
+
+    @PostMapping("/redirect/apple")
+    @Operation(summary = "Oauth 애플 로그인 리다이렉트 API", description = "애플 로그인 리다이렉트 API입니다.")
+    public ResultResponse<OauthResponse.ServerAccessTokenInfo> appleRedirect(@RequestParam("code") String code,
+                                                                             HttpServletResponse response) {
+        return ResultResponse.of(LOGIN, appleOauthService.loginApple(code, response));
     }
 
 }

--- a/src/main/java/com/unithon/aeio/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/unithon/aeio/domain/member/converter/MemberConverter.java
@@ -1,6 +1,7 @@
 package com.unithon.aeio.domain.member.converter;
 
 
+import com.unithon.aeio.domain.member.dto.AppleInfoResponse;
 import com.unithon.aeio.domain.member.dto.MemberResponse;
 import com.unithon.aeio.domain.member.dto.OauthResponse;
 import com.unithon.aeio.domain.member.entity.Member;
@@ -18,6 +19,13 @@ public class MemberConverter {
                 .name(kakaoInfo.getName()) //카카오톡 이름
                 .email(kakaoInfo.getEmail())
                 .refreshToken(kakaoInfo.getRefreshToken()) // UserDTO의 리프레시 토큰을 User 엔티티의 리프레시 토큰으로 설정
+                .build();
+    }
+
+    public Member toAppleUserEntity(AppleInfoResponse appleInfo) {
+        return Member.builder()
+                .authId(appleInfo.getAuthId())   // String
+                .email(appleInfo.getEmail())     // null일 수도 있음
                 .build();
     }
 

--- a/src/main/java/com/unithon/aeio/domain/member/dto/AppleInfoResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/AppleInfoResponse.java
@@ -1,0 +1,13 @@
+package com.unithon.aeio.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class AppleInfoResponse {
+    private String authId;  // 애플 sub
+    private String email;   // 있을 수도 있고, 없을 수도 있음
+}

--- a/src/main/java/com/unithon/aeio/domain/member/dto/ApplePublicKeyDto.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/ApplePublicKeyDto.java
@@ -1,0 +1,13 @@
+package com.unithon.aeio.domain.member.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplePublicKeyDto {
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}

--- a/src/main/java/com/unithon/aeio/domain/member/dto/ApplePublicKeysResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/ApplePublicKeysResponse.java
@@ -1,0 +1,10 @@
+package com.unithon.aeio.domain.member.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ApplePublicKeysResponse {
+    private List<ApplePublicKeyDto> keys;
+}

--- a/src/main/java/com/unithon/aeio/domain/member/dto/AppleTokenResponseDto.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/AppleTokenResponseDto.java
@@ -1,0 +1,18 @@
+package com.unithon.aeio.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class AppleTokenResponseDto {
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+    @JsonProperty("expires_in")
+    private String expiresIn;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/java/com/unithon/aeio/domain/member/dto/KakaoInfoResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/KakaoInfoResponse.java
@@ -8,7 +8,7 @@ import java.util.Map;
 @Getter
 @AllArgsConstructor
 public class KakaoInfoResponse {
-    private Long authId;
+    private String authId;
     private String name;
     private String email;
 
@@ -18,7 +18,7 @@ public class KakaoInfoResponse {
         // attributes 맵에서 "id" 키의 값이 존재하면 이를 Long 타입으로 변환하여 authId 필드에 저장하고,
         // 존재하지 않으면 null로 설정
         this.authId = attributes.get("id") != null
-                ? Long.valueOf(attributes.get("id").toString())
+                ? attributes.get("id").toString()
                 : null;
 
         // attributes 맵에서 "email" 키의 값이 존재하면 이를 String으로 변환하여 email 필드에 저장하고,

--- a/src/main/java/com/unithon/aeio/domain/member/dto/OauthRequest.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/OauthRequest.java
@@ -20,6 +20,6 @@ public abstract class OauthRequest {
     @AllArgsConstructor
     public static class LoginRequest {
         @NotNull(message = "카카오에서 제공한 회원 번호를 필수로 입력해야 합니다.")
-        private Long authId;
+        private String authId;
     }
 }

--- a/src/main/java/com/unithon/aeio/domain/member/dto/OauthResponse.java
+++ b/src/main/java/com/unithon/aeio/domain/member/dto/OauthResponse.java
@@ -19,7 +19,7 @@ public abstract class  OauthResponse {
     @Builder
     @AllArgsConstructor
     public static class KakaoInfo {
-        private Long authId;
+        private String authId;
         private String name; //카카오 설정 이름
         private String email; //카카오 설정 이메일
         private String refreshToken;

--- a/src/main/java/com/unithon/aeio/domain/member/entity/Member.java
+++ b/src/main/java/com/unithon/aeio/domain/member/entity/Member.java
@@ -41,7 +41,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
     @Column
-    private Long authId;
+    private String authId;
     @Column
     private String name;
     @Column

--- a/src/main/java/com/unithon/aeio/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/unithon/aeio/domain/member/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByAuthId(Long authId);
+    Optional<Member> findByAuthId(String authId);
     Optional<Member> findByRefreshToken(String refreshToken);
-    Boolean existsByAuthId(Long authId);
+    Boolean existsByAuthId(String authId);
 }

--- a/src/main/java/com/unithon/aeio/domain/member/service/AppleOauthService.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/AppleOauthService.java
@@ -1,0 +1,212 @@
+package com.unithon.aeio.domain.member.service;
+
+import com.unithon.aeio.domain.member.converter.MemberConverter;
+import com.unithon.aeio.domain.member.dto.AppleInfoResponse;
+import com.unithon.aeio.domain.member.dto.ApplePublicKeyDto;
+import com.unithon.aeio.domain.member.dto.ApplePublicKeysResponse;
+import com.unithon.aeio.domain.member.dto.AppleTokenResponseDto;
+import com.unithon.aeio.domain.member.dto.OauthResponse;
+import com.unithon.aeio.domain.member.entity.Member;
+import com.unithon.aeio.domain.member.repository.MemberRepository;
+import com.unithon.aeio.global.error.BusinessException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+import java.util.List;
+
+import static com.unithon.aeio.global.error.code.JwtErrorCode.APPLE_LOGIN_FAILED;
+import static com.unithon.aeio.global.error.code.JwtErrorCode.INVALID_ACCESS_TOKEN;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AppleOauthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenService jwtTokenService;
+    private final MemberConverter memberConverter;
+
+    // WebClient 하나 안에서 재사용
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://appleid.apple.com")
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=utf-8")
+            .build();
+
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    @Value("${oauth.apple.team-id}")
+    private String teamId;
+
+    @Value("${oauth.apple.key-id}")
+    private String keyId;
+
+    @Value("${oauth.apple.private-key}")
+    private String privateKey; // BASE64 본문
+
+    private static final long THIRTY_DAYS_MS = 29L * 24 * 60 * 60 * 1000;
+
+    public OauthResponse.ServerAccessTokenInfo loginApple(String code, HttpServletResponse response) {
+        // 1. code -> 애플 토큰 교환
+        AppleTokenResponseDto tokenResponse = getAppleToken(code);
+
+        // 2. id_token 검증 + 유저정보 추출
+        AppleInfoResponse appleInfo = parseAndVerifyIdToken(tokenResponse.getIdToken());
+
+        // 3. authId(String) 기준으로 Member 조회/생성
+        Member member = memberRepository.findByAuthId(appleInfo.getAuthId())
+                .orElseGet(() -> createAppleMember(appleInfo));
+
+        // 4. 우리 서버 access/refresh 발급 + 쿠키 세팅
+        String accessToken = issueServerTokens(member, response);
+
+        // 5. Kakao와 동일하게 ServerAccessTokenInfo로 래핑
+        return memberConverter.toServerAccessTokenInfo(accessToken, member);
+    }
+
+    // ------------------ 내부 메서드들 ------------------
+
+    private AppleTokenResponseDto getAppleToken(String code) {
+        try {
+            return webClient.post()
+                    .uri("/auth/token")
+                    .body(BodyInserters
+                            .fromFormData("grant_type", "authorization_code")
+                            .with("client_id", clientId)
+                            .with("client_secret", makeClientSecretToken())
+                            .with("code", code))
+                    .retrieve()
+                    .bodyToMono(AppleTokenResponseDto.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("[애플 로그인 실패] token 요청 실패: " + e.getResponseBodyAsString(), e);
+            throw new BusinessException(APPLE_LOGIN_FAILED);
+        }
+    }
+
+    private AppleInfoResponse parseAndVerifyIdToken(String idToken) {
+        try {
+            // 1. 애플 공개키 목록 가져오기
+            List<ApplePublicKeyDto> publicKeys = getApplePublicKeys();
+
+            // 2. kid -> 공개키 매칭하는 Locator
+            MyKeyLocator keyLocator = new MyKeyLocator(publicKeys);
+
+            // 3. JJWT 파서로 서명 검증 + payload 파싱
+            Claims claims = Jwts.parser()
+                    .keyLocator(keyLocator)
+                    .requireIssuer("https://appleid.apple.com")
+                    .requireAudience(clientId)
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+
+            Date exp = claims.getExpiration();
+            if (exp != null && exp.before(new Date())) {
+                throw new BusinessException(INVALID_ACCESS_TOKEN);
+            }
+
+            String sub = claims.getSubject();
+            String email = claims.get("email", String.class);
+
+            log.info("[애플 로그인] idToken 검증 완료: sub={}, email={}", sub, email);
+
+            return AppleInfoResponse
+                    .builder()
+                    .authId(sub)
+                    .email(email)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("[애플 로그인 실패] idToken 검증 실패", e);
+            throw new BusinessException(APPLE_LOGIN_FAILED);
+        }
+    }
+
+    private List<ApplePublicKeyDto> getApplePublicKeys() {
+        try {
+            ApplePublicKeysResponse response = webClient.get()
+                    .uri("/auth/keys")
+                    .retrieve()
+                    .bodyToMono(ApplePublicKeysResponse.class)
+                    .block();
+
+            if (response == null || response.getKeys() == null || response.getKeys().isEmpty()) {
+                throw new BusinessException(APPLE_LOGIN_FAILED);
+            }
+            return response.getKeys();
+        } catch (WebClientResponseException e) {
+            log.error("[애플 로그인 실패] public key 조회 실패: " + e.getResponseBodyAsString(), e);
+            throw new BusinessException(APPLE_LOGIN_FAILED);
+        }
+    }
+
+    private String makeClientSecretToken() {
+        try {
+            String token = Jwts.builder()
+                    .subject(clientId) // sub
+                    .issuer(teamId)    // iss
+                    .issuedAt(new Date())  // iat
+                    .expiration(new Date(System.currentTimeMillis() + THIRTY_DAYS_MS)) // exp
+                    .audience().add("https://appleid.apple.com").and() // aud
+                    .header().keyId(keyId).and() // kid
+                    .signWith(getPrivateKey(), Jwts.SIG.ES256)         // alg=ES256
+                    .compact();
+
+            log.info("[애플 로그인] client_secret 생성 완료");
+            return token;
+        } catch (Exception e) {
+            log.error("[애플 로그인 실패] client_secret 생성 실패", e);
+            throw new BusinessException(APPLE_LOGIN_FAILED);
+        }
+    }
+
+    private PrivateKey getPrivateKey() {
+        try {
+            byte[] privateKeyBytes = Decoders.BASE64.decode(privateKey);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            log.error("[애플 로그인 실패] private key 생성 실패", e);
+            throw new BusinessException(APPLE_LOGIN_FAILED);
+        }
+    }
+
+    private Member createAppleMember(AppleInfoResponse appleInfo) {
+        Member member = memberConverter.toAppleUserEntity(appleInfo);
+        member.setAuthId(appleInfo.getAuthId());   // String
+        member.setEmail(appleInfo.getEmail());
+        return memberRepository.save(member);
+    }
+
+    private String issueServerTokens(Member member, HttpServletResponse response) {
+        final String accessToken = jwtTokenService.createAccessToken(member.getAuthId());
+        final String refreshToken = jwtTokenService.createRefreshToken();
+
+        member.setAccessToken(accessToken);
+        member.setRefreshToken(refreshToken);
+        memberRepository.save(member);
+
+        jwtTokenService.addRefreshTokenToCookie(refreshToken, response);
+
+        return accessToken;
+    }
+}

--- a/src/main/java/com/unithon/aeio/domain/member/service/MyKeyLocator.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/MyKeyLocator.java
@@ -1,0 +1,49 @@
+package com.unithon.aeio.domain.member.service;
+
+import com.unithon.aeio.domain.member.dto.ApplePublicKeyDto;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.LocatorAdapter;
+
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+public class MyKeyLocator extends LocatorAdapter<Key> {
+
+    private final List<ApplePublicKeyDto> publicKeyList;
+
+    public MyKeyLocator(List<ApplePublicKeyDto> publicKeyList) {
+        this.publicKeyList = publicKeyList;
+    }
+
+    @Override
+    protected Key locate(JwsHeader header) {
+        Optional<ApplePublicKeyDto> optionalPublicKey = publicKeyList.stream()
+                .filter(applePublicKey -> applePublicKey.getKid().equals(header.getKeyId()))
+                .findFirst();
+
+        if (optionalPublicKey.isEmpty()) {
+            throw new RuntimeException(
+                    "일치하는 public key 가 없습니다. kid=" + header.getKeyId());
+        }
+
+        ApplePublicKeyDto publicKey = optionalPublicKey.get();
+
+        BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.getN()));
+        BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.getE()));
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            KeySpec keySpec = new RSAPublicKeySpec(n, e);
+            return keyFactory.generatePublic(keySpec);
+        } catch (Exception error) {
+            throw new RuntimeException("[애플 로그인] public key 추출 실패: " + error.getMessage(), error);
+        }
+    }
+}
+

--- a/src/main/java/com/unithon/aeio/domain/member/service/OauthService.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/OauthService.java
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public interface OauthService {
     OauthResponse.ServerAccessTokenInfo login(OauthRequest.FrontAccessTokenInfo oauthRequest, HttpServletResponse response);
     String refreshAccessToken(String refreshToken);
-    String getTokens(Long id, HttpServletResponse response);
+    String getTokens(String id, HttpServletResponse response);
     String loginWithKakao(String accessToken, HttpServletResponse response);
     OauthResponse.RefreshTokenResponse tokenRefresh(HttpServletRequest request);
     OauthResponse.CheckMemberRegistration checkRegistration(OauthRequest.LoginRequest request);

--- a/src/main/java/com/unithon/aeio/domain/member/service/OauthServiceImpl.java
+++ b/src/main/java/com/unithon/aeio/domain/member/service/OauthServiceImpl.java
@@ -94,9 +94,9 @@ public class OauthServiceImpl implements OauthService {
 
     @Override
     //액세스토큰, 리프레시토큰 생성하고 DB에 저장
-    public String getTokens(Long id, HttpServletResponse response) {
+    public String getTokens(String id, HttpServletResponse response) {
         //사용자의 ID를 바탕으로 Access Token을 생성
-        final String accessToken = jwtTokenService.createAccessToken(id.toString());
+        final String accessToken = jwtTokenService.createAccessToken(id);
         //Refresh Token을 생성
         final String refreshToken = jwtTokenService.createRefreshToken();
 
@@ -132,5 +132,4 @@ public class OauthServiceImpl implements OauthService {
         // 유효한 Refresh Token을 기반으로 새로운 Access Token을 생성하여 반환
         return jwtTokenService.createAccessToken(member.getAuthId().toString());
     }
-
 }

--- a/src/main/java/com/unithon/aeio/domain/review/entity/Review.java
+++ b/src/main/java/com/unithon/aeio/domain/review/entity/Review.java
@@ -51,6 +51,7 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "member_class_id")
     private MemberClass memberClass;
 
+    @Builder.Default
     @OneToMany(mappedBy = "review", fetch = FetchType.LAZY)
     private List<ReviewPhoto> photoList = new ArrayList<>();
 

--- a/src/main/java/com/unithon/aeio/global/error/code/JwtErrorCode.java
+++ b/src/main/java/com/unithon/aeio/global/error/code/JwtErrorCode.java
@@ -13,6 +13,7 @@ public enum JwtErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(403, "EJ004", "유효하지않은 리프레시 토큰입니다."),
     MEMBER_NOT_FOUND(404, "EJ005", "해당 회원이 존재하지 않습니다. 탈퇴한 회원인지 확인해 주세요."),
     MEMBER_NOT_FOUND_BY_AUTH_ID(405, "EG006", "authId로 멤버를 찾을 수 없습니다."),
+    APPLE_LOGIN_FAILED(404, "EJ007", "애플 로그인에 실패하였습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/unithon/aeio/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/unithon/aeio/global/security/filter/JwtFilter.java
@@ -51,8 +51,7 @@ public class JwtFilter extends GenericFilterBean {
         if (StringUtils.hasText(jwt) && jwtTokenService.validateToken(jwt)) {
 
             // JWT에서 사용자 authID를 추출
-            Long authId = Long.valueOf(jwtTokenService.getPayload(jwt)); // 토큰에 있는 authId 가져오기
-
+            String authId = jwtTokenService.getPayload(jwt); // 토큰에 있는 authId 가져오기
 
             // 추출한 사용자 ID로 데이터베이스에서 사용자 정보를 조회
             Member member = memberRepository.findByAuthId(authId)


### PR DESCRIPTION
1. 사용자가 “Sign in with Apple” 버튼 클릭
2. 애플 로그인/동의 화면 → 로그인 성공
3. 애플이 code를 들고 AEIO 서버의 https://aeio.online/oauth/redirect/apple 로 요청
4. 서버는 code로 애플의 /auth/token에 요청 → id_token 포함한 토큰 묶음 수신
5. id_token을 애플 공개키로 검증하고, 그 안의 sub, email 등을 꺼냄
6. sub를 authId(String)로 삼아서 Member를 찾거나 새로 만들고, 우리 서비스용 JWT AccessToken + RefreshToken 발급
7. AccessToken은 응답 JSON으로, RefreshToken은 쿠키로 반효ㅏㄴ